### PR TITLE
feat:subject구현_controller 주석추가

### DIFF
--- a/src/main/java/com/example/subsub/controller/SubjectApiController.java
+++ b/src/main/java/com/example/subsub/controller/SubjectApiController.java
@@ -1,5 +1,6 @@
 package com.example.subsub.controller;
 
+import com.example.subsub.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,10 +14,13 @@ import com.example.subsub.service.SubjectService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @Tag(name = "메인페이지", description = "메인페이지- 과목추가 API")
 @RestController
@@ -40,6 +44,14 @@ public class SubjectApiController {
         Subject savedSubject = subjectService.save(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SubjectDTO.toSubjectDto(savedSubject));
     }
+/*
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+
+    public Subject subjectWriteForm(@RequestPart SubjectDTO subjectDTO, @RequestPart MultipartFile multipartFile, @RequestPart User user) throws Exception {
+        subjectService.saveUser(user);//유저 정보 담는 함수
+        return subjectService.write(subjectDTO, multipartFile, user);
+    }
+*/
 
     @Operation(summary = "과목 정보 보여지기", description = "입력된 과목 정보를 확인합니다", tags = { "Subject Controller" })
     @ApiResponses({
@@ -54,6 +66,11 @@ public class SubjectApiController {
         Subject subject = subjectService.findById(id);
         return ResponseEntity.ok().body(new SubjectResponse(subject));
     }
+    /*
+    @GetMapping("/{id}")
+    public Optional<Subject> get(@PathVariable Integer id) {return subjectService.postView(id);
+    }
+     */
 
     @Operation(summary = "과목 정보 삭제", description = "입력된 과목 정보가 삭제됩니다.", tags = { "Subject Controller" })
     @ApiResponses({


### PR DESCRIPTION
무엇을?
과목 추가 controller 수정하였습니다. 

상세 설명
user정보 함수를 받아와서 subject와 연결하는 부분 주석 처리해서 올립니다.
user함수 완성 후 함수 이름 통일 시켜 주석을 지워줘야 합니다

추가 사항
이전 pr에서 주석 부분이 안 올라가서 다시 올립니다.